### PR TITLE
Align columns

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -177,6 +177,7 @@ class PMM_AddonPreferences(bpy.types.AddonPreferences):
         if TEXT_OUTPUT != []:
             row = layout.row(align=True)
             box = row.box()
+            box = box.column(align=True)
             for i in TEXT_OUTPUT:
                 row = box.row()
                 for s in i:
@@ -189,6 +190,7 @@ class PMM_AddonPreferences(bpy.types.AddonPreferences):
             # row.label(text="Error messages:")
             row = layout.row(align=True)
             box = row.box()
+            box = box.column(align=True)
             for i in ERROR_OUTPUT:
                 row = box.row()
                 for s in i:


### PR DESCRIPTION
The column alignment needs to be after box definition, or else it won't have any effect. This results in less space between the lines.