### PR TITLE
install to site packages instead of user appdata

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ __version__ = ".".join(map(str, bl_info["version"]))
 import sys
 import subprocess
 import bpy
+from pathlib import Path
 
 
 if bpy.app.version < (2, 91, 0):
@@ -97,7 +98,7 @@ class PMM_OT_PIPInstall(bpy.types.Operator):
             "install",
             *bpy.context.scene.pip_module_name.split(" "),
             "--target",
-            str(bpy.utils.script_path_user()),
+            Path(bpy.utils.script_path_user()) / "addons/modules",
         )
         return {"FINISHED"}
 

--- a/__init__.py
+++ b/__init__.py
@@ -15,25 +15,13 @@ bl_info = {
 
 __version__ = ".".join(map(str, bl_info["version"]))
 
-# add user site to sys.path
-# binaries go to {site.USER_BASE}/bin
 # venv notice:
-#   https://stackoverflow.com/questions/33412974/
-#   how-to-uninstall-a-package-installed-with-pip-install-user/56948334#56948334
-# import site
+# https://stackoverflow.com/questions/33412974/how-to-uninstall-a-package-installed-with-pip-install-user
 import sys
 import subprocess
-
-# app_path = site.getusersitepackages()
-# print("Blender PIP user site:", app_path)
-# if app_path not in sys.path:
-#     print("Adding site to path")
-#     sys.path.append(app_path)
-
 import bpy
 from pathlib import Path
 
-# MODULES_FOLDER = Path(bpy.utils.user_resource("SCRIPTS")) / "modules"
 
 if bpy.app.version < (2, 91, 0):
     python_bin = bpy.app.binary_path_python
@@ -106,12 +94,10 @@ class PMM_OT_PIPInstall(bpy.types.Operator):
 
     def execute(self, context):
         target_path = Path(python_bin).parent.parent / "lib" / "site-packages"
-        # chosen_path = "--user" if bpy.context.scene.pip_user_flag else None
         run_pip_command(
             self,
             "install",
             *bpy.context.scene.pip_module_name.split(" "),
-            # chosen_path,
             "--target",
             str(target_path),
         )
@@ -177,9 +163,6 @@ class PMM_AddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        # row.prop(bpy.context.scene, "pip_user_flag", text="As local user")
-        # TODO: implement storing Python modules into Blender module home
-        # row.prop(bpy.context.scene, "pip_modules_home", text="Use Blender modules location")
 
         row = layout.row()
         row.operator(PMM_OT_EnsurePIP.bl_idname, text="Ensure PIP")
@@ -235,7 +218,6 @@ def register():
         bpy.utils.register_class(c)
 
     bpy.types.Scene.pip_modules_home = bpy.props.BoolProperty(default=False)
-    # bpy.types.Scene.pip_user_flag = bpy.props.BoolProperty(default=True)
     bpy.types.Scene.pip_advanced_toggle = bpy.props.BoolProperty(default=False)
     bpy.types.Scene.pip_module_name = bpy.props.StringProperty()
 
@@ -245,6 +227,5 @@ def unregister():
         bpy.utils.unregister_class(c)
 
     del bpy.types.Scene.pip_modules_home
-    # del bpy.types.Scene.pip_user_flag
     del bpy.types.Scene.pip_advanced_toggle
     del bpy.types.Scene.pip_module_name

--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,6 @@ __version__ = ".".join(map(str, bl_info["version"]))
 import sys
 import subprocess
 import bpy
-from pathlib import Path
 
 
 if bpy.app.version < (2, 91, 0):
@@ -93,13 +92,12 @@ class PMM_OT_PIPInstall(bpy.types.Operator):
     bl_description = "Install PIP packages"
 
     def execute(self, context):
-        target_path = Path(python_bin).parent.parent / "lib" / "site-packages"
         run_pip_command(
             self,
             "install",
             *bpy.context.scene.pip_module_name.split(" "),
             "--target",
-            str(target_path),
+            str(bpy.utils.script_path_user()),
         )
         return {"FINISHED"}
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+
 bl_info = {
     "name": "Python Module Manager",
     "author": "ambi",
@@ -19,22 +20,20 @@ __version__ = ".".join(map(str, bl_info["version"]))
 # venv notice:
 #   https://stackoverflow.com/questions/33412974/
 #   how-to-uninstall-a-package-installed-with-pip-install-user/56948334#56948334
-import site
+# import site
 import sys
 import subprocess
 
-app_path = site.getusersitepackages()
-print("Blender PIP user site:", app_path)
-if app_path not in sys.path:
-    print("Adding site to path")
-    sys.path.append(app_path)
+# app_path = site.getusersitepackages()
+# print("Blender PIP user site:", app_path)
+# if app_path not in sys.path:
+#     print("Adding site to path")
+#     sys.path.append(app_path)
 
 import bpy
-import numpy as np
-import mathutils as mu
 from pathlib import Path
 
-MODULES_FOLDER = Path(bpy.utils.user_resource("SCRIPTS")) / "modules"
+# MODULES_FOLDER = Path(bpy.utils.user_resource("SCRIPTS")) / "modules"
 
 if bpy.app.version < (2, 91, 0):
     python_bin = bpy.app.binary_path_python
@@ -106,12 +105,15 @@ class PMM_OT_PIPInstall(bpy.types.Operator):
     bl_description = "Install PIP packages"
 
     def execute(self, context):
-        chosen_path = "--user" if bpy.context.scene.pip_user_flag else None
+        target_path = Path(python_bin).parent.parent / "lib" / "site-packages"
+        # chosen_path = "--user" if bpy.context.scene.pip_user_flag else None
         run_pip_command(
             self,
             "install",
             *bpy.context.scene.pip_module_name.split(" "),
-            chosen_path,
+            # chosen_path,
+            "--target",
+            str(target_path),
         )
         return {"FINISHED"}
 
@@ -175,7 +177,7 @@ class PMM_AddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        row.prop(bpy.context.scene, "pip_user_flag", text="As local user")
+        # row.prop(bpy.context.scene, "pip_user_flag", text="As local user")
         # TODO: implement storing Python modules into Blender module home
         # row.prop(bpy.context.scene, "pip_modules_home", text="Use Blender modules location")
 
@@ -233,7 +235,7 @@ def register():
         bpy.utils.register_class(c)
 
     bpy.types.Scene.pip_modules_home = bpy.props.BoolProperty(default=False)
-    bpy.types.Scene.pip_user_flag = bpy.props.BoolProperty(default=True)
+    # bpy.types.Scene.pip_user_flag = bpy.props.BoolProperty(default=True)
     bpy.types.Scene.pip_advanced_toggle = bpy.props.BoolProperty(default=False)
     bpy.types.Scene.pip_module_name = bpy.props.StringProperty()
 
@@ -243,6 +245,6 @@ def unregister():
         bpy.utils.unregister_class(c)
 
     del bpy.types.Scene.pip_modules_home
-    del bpy.types.Scene.pip_user_flag
+    # del bpy.types.Scene.pip_user_flag
     del bpy.types.Scene.pip_advanced_toggle
     del bpy.types.Scene.pip_module_name

--- a/init_utils.bat
+++ b/init_utils.bat
@@ -1,1 +1,0 @@
-git clone https://github.com/amb/bpy_amb.git


### PR DESCRIPTION
fix for https://github.com/amb/blender_pip/issues/9

blender pip now installs to the blender modules folder.
specifically, site packages, which keeps it separated from the default python modules included with blender